### PR TITLE
Translate reflection tutorial notebook to Korean

### DIFF
--- a/docs/docs/tutorials/reflection/reflection.ipynb
+++ b/docs/docs/tutorials/reflection/reflection.ipynb
@@ -10,15 +10,13 @@
    "id": "492f050f-3dc3-44fa-8fdc-03362afd5488",
    "metadata": {},
    "source": [
-    "# Reflection\n",
+    "# 리플렉션\n",
     "\n",
-    "\n",
-    "In the context of LLM agent building, reflection refers to the process of prompting an LLM to observe its past steps (along with potential observations from tools/the environment) to assess the quality of the chosen actions.\n",
-    "This is then used downstream for things like re-planning, search, or evaluation.\n",
+    "LLM 에이전트를 구축하는 맥락에서 리플렉션은 LLM이 과거 단계(도구나 환경에서 얻은 관찰을 포함)를 살펴보고 선택한 행동의 품질을 평가하도록 프롬프트하는 과정을 의미합니다. 이러한 결과는 이후 재계획, 탐색 또는 평가와 같은 작업에 활용됩니다.\n",
     "\n",
     "![Reflection](attachment:fc393f72-3401-4b86-b0d3-e4789b640a27.png)\n",
     "\n",
-    "This notebook demonstrates a very simple form of reflection in LangGraph."
+    "이 노트북은 LangGraph에서 매우 간단한 형태의 리플렉션을 보여 줍니다.\n"
    ]
   },
   {
@@ -26,9 +24,9 @@
    "id": "3ef94e7e-c9a5-4eee-a865-acf411b5c235",
    "metadata": {},
    "source": [
-    "## Setup\n",
+    "## 준비\n",
     "\n",
-    "First, let's install our required packages and set our API keys"
+    "우선 필요한 패키지를 설치하고 API 키를 설정해 봅시다.\n"
    ]
   },
   {
@@ -69,11 +67,11 @@
    "metadata": {},
    "source": [
     "<div class=\"admonition tip\">\n",
-    "    <p class=\"admonition-title\">Set up <a href=\"https://smith.langchain.com\">LangSmith</a> for LangGraph development</p>\n",
+    "    <p class=\"admonition-title\">LangGraph 개발을 위해 <a href=\"https://smith.langchain.com\">LangSmith</a> 설정하기</p>\n",
     "    <p style=\"padding-top: 5px;\">\n",
-    "        Sign up for LangSmith to quickly spot issues and improve the performance of your LangGraph projects. LangSmith lets you use trace data to debug, test, and monitor your LLM apps built with LangGraph — read more about how to get started <a href=\"https://docs.smith.langchain.com\">here</a>. \n",
+    "        LangSmith에 가입하면 LangGraph 프로젝트의 문제를 빠르게 파악하고 성능을 향상시킬 수 있습니다. LangSmith는 LangGraph로 구축한 LLM 앱을 디버그하고, 테스트하고, 모니터링할 수 있도록 추적 데이터를 제공합니다. 시작 방법은 <a href=\"https://docs.smith.langchain.com\">여기</a>에서 자세히 알아보세요.\n",
     "    </p>\n",
-    "</div>"
+    "</div>\n"
    ]
   },
   {
@@ -81,9 +79,10 @@
    "id": "f27bcc4a-aaa5-46bd-8163-3e0e90cb66e6",
    "metadata": {},
    "source": [
-    "## Generate\n",
+    "## 생성\n",
     "\n",
-    "For our example, we will create a \"5 paragraph essay\" generator. First, create the generator:\n"
+    "예제로 \"5 단락 에세이\" 생성기를 만들어 보겠습니다. 먼저 생성기를 정의합니다:\n",
+    "\n"
    ]
   },
   {
@@ -161,7 +160,7 @@
    "id": "b0b276e7-c392-4eec-be75-c77bd130379d",
    "metadata": {},
    "source": [
-    "### Reflect"
+    "### 리플렉션\n"
    ]
   },
   {
@@ -238,9 +237,9 @@
    "id": "6daf926c-1174-4e96-91b9-57c57cfce40d",
    "metadata": {},
    "source": [
-    "### Repeat\n",
+    "### 반복\n",
     "\n",
-    "And... that's all there is too it! You can repeat in a loop for a fixed number of steps, or use an LLM (or other check) to decide when the finished product is good enough."
+    "바로 이게 전부입니다! 고정된 횟수만큼 반복하거나, LLM(또는 다른 검증 절차)을 사용해 결과가 충분히 만족스러운지 결정할 수 있습니다.\n"
    ]
   },
   {
@@ -307,9 +306,9 @@
    "id": "b63a9d93-a14d-4e41-a4bb-a4cd31713f44",
    "metadata": {},
    "source": [
-    "## Define graph\n",
+    "## 그래프 정의\n",
     "\n",
-    "Now that we've shown each step in isolation, we can wire it up in a graph."
+    "각 단계를 개별적으로 확인했으니 이제 그래프에 연결해 봅시다.\n"
    ]
   },
   {
@@ -605,9 +604,10 @@
     "jp-MarkdownHeadingCollapsed": true
    },
    "source": [
-    "## Conclusion\n",
+    "## 마무리\n",
     "\n",
-    "Now that you've applied reflection to an LLM agent, I'll note one thing: self-reflection is inherently cyclic: it is much more effective if the reflection step has additional context or feedback (from tool observations, checks, etc.). If, like in the scenario above, the reflection step simply prompts the LLM to reflect on its output, it can still benefit the output quality (since the LLM then has multiple \"shots\" at getting a good output), but it's less guaranteed.\n"
+    "이제 LLM 에이전트에 리플렉션을 적용했으니 한 가지를 덧붙이겠습니다. 자기 성찰은 본질적으로 순환적이어서, 리플렉션 단계가 추가적인 문맥이나 피드백(도구 관찰, 검사 등)을 받을수록 훨씬 더 효과적입니다. 위 시나리오처럼 리플렉션 단계가 단순히 LLM에게 자신의 출력을 되돌아보라고 요청하는 것이라 하더라도, 여러 번 기회를 주어 결과 품질을 높이는 데 도움이 될 수 있지만 보장은 다소 떨어집니다.\n",
+    "\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- translate the reflection tutorial notebook markdown content into Korean for localized guidance

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd36c022488322a3f3e54c155866a2